### PR TITLE
Remove Model Type-Hint

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -71,8 +71,11 @@ class Builder
         if (! $schedule = $this->schedule()) {
             return false;
         }
+        if (! $next = $schedule->next()) {
+            return false;
+        }
 
-        return Carbon::instance($schedule->next()->getStart());
+        return Carbon::instance($next->getStart());
     }
 
     /**

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -25,18 +25,18 @@ use Recurr\Transformer\ArrayTransformerConfig;
 
 class Builder
 {
-    /** @var \DateTime */
-    private $model;
+    /** @var mixed */
+    private $recurring;
 
-    /** @var \DateTime */
+    /** @var \BrianFaust\Recurring\Config */
     private $config;
 
     /**
-     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param mixed  $recurring
      */
-    public function __construct(Model $model)
+    public function __construct($recurring)
     {
-        $this->model = $model;
+        $this->recurring = $recurring;
         $this->config = $this->buildConfig();
     }
 
@@ -160,7 +160,7 @@ class Builder
      */
     private function buildConfig(): Config
     {
-        $config = $this->model->getRecurringConfig();
+        $config = $this->recurring->getRecurringConfig();
 
         return new Config(
             $config['start_date'], $config['end_date'], $config['timezone'],

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -19,7 +19,6 @@ use DateTimeZone;
 use Carbon\Carbon;
 use Recurr\Frequency;
 use Recurr\RecurrenceCollection;
-use Illuminate\Database\Eloquent\Model;
 use Recurr\Transformer\ArrayTransformer;
 use Recurr\Transformer\ArrayTransformerConfig;
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -55,7 +55,7 @@ class Config implements Arrayable
      * @param int         $interval
      * @param int         $count
      */
-    public function __construct(string $startDate, $endDate, string $timezone, string $frequency, int $interval, ?int $count)
+    public function __construct(string $startDate, $endDate, string $timezone, string $frequency, int $interval, int $count = null)
     {
         $this->startDate = $startDate;
         $this->endDate = $endDate;

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace BrianFaust\Tests\Flash;
+namespace BrianFaust\Tests\Recurring;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
+abstract class AbstractTestCase extends TestCase
 {
 }

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Laravel Recurring.
+ *
+ * (c) Brian Faust <hello@brianfaust.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace BrianFaust\Tests\Recurring;
+
+use Carbon\Carbon;
+
+class BuilderTest extends AbstractTestCase
+{
+    /** @test */
+    public function next_returns_carbon_instance()
+    {
+        $recurring = new RecurringClass(['count' => 2]);
+
+        $builder = $recurring->recurr();
+
+        $this->assertTrue($builder->next() instanceof Carbon);
+    }
+
+    /** @test */
+    public function next_returns_false_if_no_more_recurrances()
+    {
+        $recurring = new RecurringClass(['count' => 1]);
+
+        $builder = $recurring->recurr();
+
+        $this->assertFalse($builder->next());
+    }
+}
+
+class RecurringClass
+{
+    use \BrianFaust\Recurring\Traits\Recurring;
+
+    private $start_at;
+    private $end_at;
+    private $timezone;
+    private $frequency;
+    private $interval;
+    private $count;
+
+    public function __construct(array $attributes = [])
+    {
+        $this->start_at = $attributes['start_at'] ?? Carbon::now()->format('Y-m-d H:i:s');
+        $this->end_at = $attributes['end_at'] ?? Carbon::now()->format('Y-m-d H:i:s');
+        $this->timezone = $attributes['timezone'] ?? Carbon::now()->format('e');
+        $this->frequency = $attributes['frequency'] ?? 'DAILY';
+        $this->interval = $attributes['interval'] ?? 1;
+        $this->count = $attributes['count'] ?? null;
+    }
+}

--- a/tests/RecurringTraitTest.php
+++ b/tests/RecurringTraitTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Laravel Recurring.
+ *
+ * (c) Brian Faust <hello@brianfaust.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace BrianFaust\Tests\Recurring;
+
+use BrianFaust\Tests\Recurring\AbstractTestCase;
+
+class RecurringTraitTest extends AbstractTestCase
+{
+    /** @test */
+    public function recurring_instantiates_builder()
+    {
+        $recurring = new RecurringExample;
+
+        $builder = $recurring->recurr();
+
+        $this->assertTrue($builder instanceof \BrianFaust\Recurring\Builder);
+    }
+}
+
+class RecurringExample
+{
+    use \BrianFaust\Recurring\Traits\Recurring;
+
+    private $start_at   = '';
+    private $end_at     = '';
+    private $timezone   = '';
+    private $frequency  = '';
+    private $interval   = 0;
+    private $count      = null;
+}

--- a/tests/RecurringTraitTest.php
+++ b/tests/RecurringTraitTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace BrianFaust\Tests\Recurring;
 
-use BrianFaust\Tests\Recurring\AbstractTestCase;
-
 class RecurringTraitTest extends AbstractTestCase
 {
     /** @test */

--- a/tests/RecurringTraitTest.php
+++ b/tests/RecurringTraitTest.php
@@ -24,9 +24,31 @@ class RecurringTraitTest extends AbstractTestCase
 
         $this->assertTrue($builder instanceof \BrianFaust\Recurring\Builder);
     }
+
+    /** @test */
+    public function recurring_model_instantiates_builder()
+    {
+        $recurring = new RecurringModelExample;
+
+        $builder = $recurring->recurr();
+
+        $this->assertTrue($builder instanceof \BrianFaust\Recurring\Builder);
+    }
 }
 
 class RecurringExample
+{
+    use \BrianFaust\Recurring\Traits\Recurring;
+
+    private $start_at = '';
+    private $end_at = '';
+    private $timezone = '';
+    private $frequency = '';
+    private $interval = 0;
+    private $count = null;
+}
+
+class RecurringModelExample extends \Illuminate\Database\Eloquent\Model
 {
     use \BrianFaust\Recurring\Traits\Recurring;
 

--- a/tests/RecurringTraitTest.php
+++ b/tests/RecurringTraitTest.php
@@ -32,10 +32,10 @@ class RecurringExample
 {
     use \BrianFaust\Recurring\Traits\Recurring;
 
-    private $start_at   = '';
-    private $end_at     = '';
-    private $timezone   = '';
-    private $frequency  = '';
-    private $interval   = 0;
-    private $count      = null;
+    private $start_at = '';
+    private $end_at = '';
+    private $timezone = '';
+    private $frequency = '';
+    private $interval = 0;
+    private $count = null;
 }


### PR DESCRIPTION
Thanks for this abstraction, looking forward to making good use of it. This PR does two things:

* Supports PHP 7.0 (removed nullable type-hint)
* Removed type-hint for an Eloquent Model so that any class can use the Recurring trait
